### PR TITLE
[refactor] Repositories 호출 부분 Coroutine으로 변경

### DIFF
--- a/최창익/app/src/main/java/com/mash_up/mvvmstudy/repository/MainRepository.kt
+++ b/최창익/app/src/main/java/com/mash_up/mvvmstudy/repository/MainRepository.kt
@@ -6,34 +6,26 @@ import com.mash_up.mvvmstudy.repository.remote.GitService
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.io.IOException
 
 class MainRepository {
     private val api: GitService = ClientFactory.createService(GitService::class.java)
 
-    fun getRepositories(
-        query: String,
-        onSuccess: (Repositories) -> Unit,
-        onError: (String) -> Unit
-    ) {
-        api.getRepositories(query).enqueue(object : Callback<Repositories> {
-            override fun onResponse(call: Call<Repositories>, response: Response<Repositories>) {
-                val resultBody = response.body()
+    suspend fun getRepositoriesCoroutine(
+        query: String
+    ): Result<Repositories?> {
+        val response = api.getRepositories(query)
 
-                if (response.isSuccessful && resultBody != null) {
-                    onSuccess(resultBody)
-                } else {
-                    onError(
-                        "code : ${response.code()}, 다음과 같은 에러가 발생했습니다. ${
-                            response.errorBody().toString()
-                        }"
-                    )
-                }
-            }
-
-            override fun onFailure(call: Call<Repositories>, t: Throwable) {
-                onError("$t")
-            }
-
-        })
+        return if (response.isSuccessful) {
+            Result.success(response.body())
+        } else {
+            Result.failure(
+                IOException(
+                    "code : ${response.code()}, 다음과 같은 에러가 발생했습니다. ${
+                        response.errorBody().toString()
+                    }"
+                )
+            )
+        }
     }
 }

--- a/최창익/app/src/main/java/com/mash_up/mvvmstudy/repository/remote/GitService.kt
+++ b/최창익/app/src/main/java/com/mash_up/mvvmstudy/repository/remote/GitService.kt
@@ -2,16 +2,17 @@ package com.mash_up.mvvmstudy.repository.remote
 
 import com.mash_up.mvvmstudy.repository.model.Repositories
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface GitService {
     @GET("/search/repositories")
-    fun getRepositories(
+    suspend fun getRepositories(
         @Query("q") query: String,
         @Query("sort") sort: String = "best match",
         @Query("order") order: String = "desc",
         @Query("per_page") per_page: String = "30",
         @Query("page") page: String = "0",
-    ): Call<Repositories>
+    ): Response<Repositories>
 }

--- a/최창익/app/src/main/java/com/mash_up/mvvmstudy/view/main/MainActivity.kt
+++ b/최창익/app/src/main/java/com/mash_up/mvvmstudy/view/main/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity() {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 if (query.isNullOrEmpty()) return false
 
-                viewModel.getRepositories(query)
+                viewModel.getRepositoriesCoroutine(query)
 
                 return true
             }

--- a/최창익/app/src/main/java/com/mash_up/mvvmstudy/view/main/MainViewModel.kt
+++ b/최창익/app/src/main/java/com/mash_up/mvvmstudy/view/main/MainViewModel.kt
@@ -3,8 +3,11 @@ package com.mash_up.mvvmstudy.view.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.mash_up.mvvmstudy.repository.model.Repository
 import com.mash_up.mvvmstudy.repository.MainRepository
+import com.mash_up.mvvmstudy.repository.model.Repositories
+import kotlinx.coroutines.launch
 
 class MainViewModel : ViewModel() {
     private val mainRepository = MainRepository()
@@ -21,15 +24,14 @@ class MainViewModel : ViewModel() {
     val networkErrorState: LiveData<String>
         get() = _networkErrorState
 
-    fun getRepositories(query: String) {
-        mainRepository.getRepositories(
-            query = query,
-            onSuccess = { response ->
-                _repositories.value = response.repositories
-            },
-            onError = { errorInfo ->
-                _networkErrorState.value = errorInfo
+    fun getRepositoriesCoroutine(query: String) = viewModelScope.launch {
+        runCatching { mainRepository.getRepositoriesCoroutine(query) }
+            .onSuccess { successResult ->
+                val repositories = successResult.getOrNull()?.repositories ?: listOf()
+                _repositories.value = repositories
             }
-        )
+            .onFailure { exception ->
+                _networkErrorState.value = exception.toString()
+            }
     }
 }


### PR DESCRIPTION
- Repositories 호출 부분 Coroutine 사용으로 변경
- runCatching과 Result를 통해 에러 핸들링

많은 리뷰 부탁드립니다! (리뷰할 코드가 별로 없을 수도 있겠네요..ㅎ)

+ 면접 당시에 Retrofit에서 suspend를 쓰면 Dispatcher 처리를 어떻게 하는지에 대한 질문을 받았었는데 이번 리팩에서 갑자기 생각이 나더군요
[https://thdev.tech/kotlin/2021/01/12/Retrofit-Coroutines/](https://thdev.tech/kotlin/2021/01/12/Retrofit-Coroutines/)
이 링크에 나와있는데, suspend를 통해 api를 호출하면 Retrofit에서 내부적으로 enqueue를 다뤄서 처리를 하기 때문에 별도의 Dispatcher 처리가 없다고 하는데 이해를 제대로 한건지 모르겠네요 허허